### PR TITLE
feat(#1): Add support for custom Cloudflare domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install medusa-file-cloudflare-images
 yarn add medusa-file-cloudflare-images
 ```
 
-## Usage
+## Basic Usage
 
 Open your `medusa.config.js` and add the below configuration
 
@@ -29,6 +29,7 @@ module.exports = {
     {
       resolve: `medusa-file-cloudflare-images`,
       options: {
+        // required
         accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
         apiToken: process.env.CLOUDFLARE_IMAGE_API_TOKEN,
       },
@@ -50,6 +51,39 @@ The account ID that is associated with your account. Click on the link above and
 #### `CLOUDFLARE_IMAGE_API_TOKEN`
 
 The API token that is going to be used to allow the plugin to upload images to the images service. Click on the link above and follow the instructions underneath the heading **Your Global API Key or API Token**
+
+## Serving images from a Cloudflare domain
+
+Cloudflare images supports serving images that you upload from any Cloudflare domain. In order to do that you need to provide the domain that you want to serve your images from and then the `account hash` of your Cloudflare images account.
+
+Once you have those, add the below to your `medusa-config.js` in the `medusa-file-cloudflare-images` plugin definition.
+
+```js
+module.exports = {
+  plugins: [
+    ...otherMedusaPlugins,
+    {
+      resolve: `medusa-file-cloudflare-images`,
+      options: {
+        // required
+        accountId: process.env.CLOUDFLARE_ACCOUNT_ID,
+        apiToken: process.env.CLOUDFLARE_IMAGE_API_TOKEN,
+        // write the domain it as you would see it in
+        // the websites tab of your Cloudflare dashboard
+        serveFromCloudflareDomain: "yourcloudflaredomain.com",
+        accountHash: process.env.CLOUDFLARE_IMAGE_ACCOUNT_HASH,
+      },
+    },
+  ],
+};
+```
+
+**Here are few useful tips on getting the keys and using this feature.**
+
+- Your `Account hash` will be under `Developer Resources` in the Images section of your Cloudflare Dashboard.
+- If you forget your `account hash`, the plugin will throw an error to help you get back on your feet.
+- The images are automatically served via `https://` so don't worry about adding that to your domain. Just write it as you see it in the Websites section of your Cloudflare Dashboard.
+- If you only include the `accountHash`, this plugin will ignore the custom domain all together and serve it using the provided image delivery URL once it's done uploading. You will need to include the `serveFromCloudflareDomain` domain string as well as the `accountHash`
 
 ## Gotchas / Errors
 


### PR DESCRIPTION
Adds 2 new fields to the plugin config
- `serveFromCloudflareDomain`
- `accountHash`
Enables the ability to serve uploaded images through a cloudlfare domain of your choosing